### PR TITLE
Signals markings signs

### DIFF
--- a/code/downloaders/signals_markings_signs/accessible_pedestrian_signals_downloader.py
+++ b/code/downloaders/signals_markings_signs/accessible_pedestrian_signals_downloader.py
@@ -1,0 +1,13 @@
+from nyc_base_downloader import NYCDataDownloader
+
+
+class AccessiblePedestrianSignalsDownloader(NYCDataDownloader):
+    BASE_URL = "https://data.cityofnewyork.us/api/views/de3m-c5p4/rows.csv?accessType=DOWNLOAD"
+    DATASET_NAME = "Accessible Pedestrian Signal Locations"
+
+def main():
+    downloader = AccessiblePedestrianSignalsDownloader()
+    downloader.run()
+
+if __name__ == "__main__":
+    main()

--- a/code/downloaders/signals_markings_signs/street_sign_downloader.py
+++ b/code/downloaders/signals_markings_signs/street_sign_downloader.py
@@ -1,0 +1,11 @@
+from nyc_base_downloader import NYCDataDownloader
+
+class StreetSignWorkOrdersDownloader(NYCDataDownloader):
+    BASE_URL = "https://data.cityofnewyork.us/api/views/qt6m-xctn/rows.csv?accessType=DOWNLOAD"
+    DATASET_NAME = "Street Sign Work Orders"
+
+def main():
+    StreetSignWorkOrdersDownloader().run()
+
+if __name__ == "__main__":
+    main()

--- a/code/processors/signals_markings_signs.py
+++ b/code/processors/signals_markings_signs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Processor: Merge NYC traffic signals, signs, and markings into one geospatial dataset.
+Only merges APS, street signs, and traffic signals — excluding speed limits.
+Removes duplicates **within each source** by its unique ID (SIGNID, F_id, etc.).
+"""
+
+import pandas as pd
+import geopandas as gpd
+import os
+
+# === Constants ===
+DATA_DIR = "data/signals_markings_signs"
+OUTPUT_PATH = os.path.join(DATA_DIR, "signals_signs_markings_combined.csv")
+WGS84 = "EPSG:4326"
+
+# === Helper: Convert df with X/Y columns to GeoDataFrame and deduplicate
+def to_gdf_from_xy(df, x_col, y_col, source_name, id_cols):
+    df = df.dropna(subset=[x_col, y_col]).copy()
+    df["geometry"] = gpd.points_from_xy(df[x_col], df[y_col])
+    gdf = gpd.GeoDataFrame(df, geometry="geometry", crs=WGS84)
+    gdf["source"] = source_name
+
+    # Try deduplicating using one of the provided ID columns
+    for col in id_cols:
+        if col in gdf.columns and gdf[col].nunique() > 100:
+            gdf["unique_id"] = gdf[col].astype(str).str.strip()
+            gdf = gdf.drop_duplicates(subset="unique_id", keep="first")
+            break
+
+    return gdf.drop(columns=["unique_id"], errors="ignore")
+
+# === Load and deduplicate each dataset ===
+datasets = []
+
+# 1. Accessible pedestrian signals
+df_aps = pd.read_csv(os.path.join(DATA_DIR, "accessible_pedestrian_signals.csv"))
+gdf_aps = to_gdf_from_xy(df_aps, "POINT_X", "POINT_Y", "accessible_ped_signal", ["F_id", "OBJECTID"])
+datasets.append(gdf_aps)
+
+# 2. Street sign work orders
+df_ss = pd.read_csv(os.path.join(DATA_DIR, "street_sign_work_orders.csv"))
+gdf_ss = to_gdf_from_xy(df_ss, "sign_x_coord", "sign_y_coord", "street_sign", ["SIGNID", "sign_id"])
+datasets.append(gdf_ss)
+
+# 3. Traffic signals
+df_ts = pd.read_csv(os.path.join(DATA_DIR, "traffic_signals.csv"))
+gdf_ts = to_gdf_from_xy(df_ts, "X", "Y", "traffic_signal", ["F_id"])
+datasets.append(gdf_ts)
+
+# === Log counts before merging
+print("\nLoaded datasets:")
+for gdf in datasets:
+    print(f" - {gdf['source'].iloc[0]:<25} → {len(gdf):,} rows")
+
+# === Merge all datasets
+combined = pd.concat(datasets, ignore_index=True)
+
+# === Save CSV
+combined.drop(columns=["geometry"], errors="ignore").to_csv(OUTPUT_PATH, index=False)
+print(f"\nFinal merged dataset saved: {OUTPUT_PATH} ({len(combined):,} rows)")

--- a/data_profiles/signals_markings_signs.json
+++ b/data_profiles/signals_markings_signs.json
@@ -1,0 +1,1379 @@
+{
+  "size": 2034662795,
+  "nb_rows": 7021652,
+  "average_row_size": 289.76981414060396,
+  "nb_profiled_rows": 17256,
+  "nb_columns": 91,
+  "columns": [
+    {
+      "name": "the_geom",
+      "structural_type": "http://schema.org/GeoCoordinates",
+      "semantic_types": [],
+      "point_format": "long,lat",
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273
+    },
+    {
+      "name": "BoroCode",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 4,
+      "mean": 2.6,
+      "stddev": 1.2806248474865698,
+      "coverage": [
+        {
+          "range": {
+            "gte": 1.0,
+            "lte": 1.0
+          }
+        },
+        {
+          "range": {
+            "gte": 2.0,
+            "lte": 2.0
+          }
+        },
+        {
+          "range": {
+            "gte": 3.0,
+            "lte": 4.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "BoroName",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 4
+    },
+    {
+      "name": "BoroCD",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9,
+      "mean": 266.7,
+      "stddev": 128.40642507289112,
+      "coverage": [
+        {
+          "range": {
+            "gte": 102.0,
+            "lte": 108.0
+          }
+        },
+        {
+          "range": {
+            "gte": 204.0,
+            "lte": 210.0
+          }
+        },
+        {
+          "range": {
+            "gte": 311.0,
+            "lte": 412.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "CounDist",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9,
+      "mean": 20.2,
+      "stddev": 13.317657451669195,
+      "coverage": [
+        {
+          "range": {
+            "gte": 2.0,
+            "lte": 16.0
+          }
+        },
+        {
+          "range": {
+            "gte": 26.0,
+            "lte": 29.0
+          }
+        },
+        {
+          "range": {
+            "gte": 47.0,
+            "lte": 47.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "AssemDist",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9,
+      "mean": 54.1,
+      "stddev": 21.323461257497573,
+      "coverage": [
+        {
+          "range": {
+            "gte": 28.0,
+            "lte": 34.0
+          }
+        },
+        {
+          "range": {
+            "gte": 47.0,
+            "lte": 47.0
+          }
+        },
+        {
+          "range": {
+            "gte": 66.0,
+            "lte": 82.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "StSenDist",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9,
+      "mean": 22.0,
+      "stddev": 8.579044235810887,
+      "coverage": [
+        {
+          "range": {
+            "gte": 10.0,
+            "lte": 17.0
+          }
+        },
+        {
+          "range": {
+            "gte": 27.0,
+            "lte": 30.0
+          }
+        },
+        {
+          "range": {
+            "gte": 32.0,
+            "lte": 34.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "CongDist",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9,
+      "mean": 9.9,
+      "stddev": 3.477067730142742,
+      "coverage": [
+        {
+          "range": {
+            "gte": 5.0,
+            "lte": 7.0
+          }
+        },
+        {
+          "range": {
+            "gte": 10.0,
+            "lte": 12.0
+          }
+        },
+        {
+          "range": {
+            "gte": 13.0,
+            "lte": 15.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "Location",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Text"
+      ],
+      "missing_values_ratio": 0.999420491423273
+    },
+    {
+      "name": "Borough",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 4
+    },
+    {
+      "name": "Date_Insta",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/DateTime"
+      ],
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 10
+    },
+    {
+      "name": "POINT_X",
+      "structural_type": "http://schema.org/Float",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "mean": -73.8992527,
+      "stddev": 0.0780177932539089,
+      "coverage": [
+        {
+          "range": {
+            "gte": -73.998085,
+            "lte": -73.957888
+          }
+        },
+        {
+          "range": {
+            "gte": -73.917533,
+            "lte": -73.848076
+          }
+        },
+        {
+          "range": {
+            "gte": -73.788289,
+            "lte": -73.768555
+          }
+        }
+      ]
+    },
+    {
+      "name": "POINT_Y",
+      "structural_type": "http://schema.org/Float",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.999420491423273,
+      "mean": 40.7438271,
+      "stddev": 0.0710016294974272,
+      "coverage": [
+        {
+          "range": {
+            "gte": 40.594602,
+            "lte": 40.672871
+          }
+        },
+        {
+          "range": {
+            "gte": 40.721366,
+            "lte": 40.761175
+          }
+        },
+        {
+          "range": {
+            "gte": 40.800375,
+            "lte": 40.850909
+          }
+        }
+      ]
+    },
+    {
+      "name": "FEMAFldz",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 2
+    },
+    {
+      "name": "FEMAFldT",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Text"
+      ],
+      "missing_values_ratio": 0.9994784422809457
+    },
+    {
+      "name": "HrcEvac",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.9997102457116366,
+      "num_distinct_values": 4,
+      "mean": 2.8,
+      "stddev": 1.469693845669907,
+      "coverage": [
+        {
+          "range": {
+            "gte": 1.0,
+            "lte": 1.0
+          }
+        },
+        {
+          "range": {
+            "gte": 2.0,
+            "lte": 2.0
+          }
+        },
+        {
+          "range": {
+            "gte": 4.0,
+            "lte": 5.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "NTAname",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.999420491423273,
+      "num_distinct_values": 9
+    },
+    {
+      "name": "source",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "num_distinct_values": 3
+    },
+    {
+      "name": "order_number",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 16977
+    },
+    {
+      "name": "record_type",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 2
+    },
+    {
+      "name": "order_type",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 10
+    },
+    {
+      "name": "borough",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 5
+    },
+    {
+      "name": "on_street",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 3164
+    },
+    {
+      "name": "on_street_suffix",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.971256374594344,
+      "num_distinct_values": 24
+    },
+    {
+      "name": "from_street",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 3514
+    },
+    {
+      "name": "from_street_suffix",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.9891052387575336,
+      "num_distinct_values": 23
+    },
+    {
+      "name": "to_street",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.423794622160408,
+      "num_distinct_values": 2570
+    },
+    {
+      "name": "to_street_suffix",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.9978558182661104,
+      "num_distinct_values": 17
+    },
+    {
+      "name": "side_of_street",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 5
+    },
+    {
+      "name": "order_completed_on_date",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/DateTime"
+      ],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 7914
+    },
+    {
+      "name": "sign_code",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 2564
+    },
+    {
+      "name": "sign_description",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Text"
+      ],
+      "missing_values_ratio": 0.0018544274455261937
+    },
+    {
+      "name": "sign_size",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.00782336578581363,
+      "num_distinct_values": 120
+    },
+    {
+      "name": "sign_design_voided_on_date",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration",
+        "http://schema.org/DateTime"
+      ],
+      "missing_values_ratio": 0.7306444135373203,
+      "num_distinct_values": 45
+    },
+    {
+      "name": "sign_location",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.5781177561427909,
+      "num_distinct_values": 59
+    },
+    {
+      "name": "distance_from_intersection",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 1250,
+      "mean": 196.8625174175569,
+      "stddev": 384.3437590018534,
+      "coverage": [
+        {
+          "range": {
+            "gte": 0.0,
+            "lte": 277.0
+          }
+        },
+        {
+          "range": {
+            "gte": 368.0,
+            "lte": 1208.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "arrow_direction",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.7545781177561428,
+      "num_distinct_values": 6
+    },
+    {
+      "name": "facing_direction",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.6980180806675939,
+      "num_distinct_values": 6
+    },
+    {
+      "name": "sheeting_type",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.10390588780713955,
+      "num_distinct_values": 5
+    },
+    {
+      "name": "support",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.002086230876216968,
+      "num_distinct_values": 48
+    },
+    {
+      "name": "sign_notes",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.7144181733889662,
+      "num_distinct_values": 4207
+    },
+    {
+      "name": "sign_x_coord",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 14269,
+      "mean": 1002613.1434045518,
+      "stddev": 25455.98665166079,
+      "coverage": [
+        {
+          "range": {
+            "gte": 981138.0,
+            "lte": 1010459.0
+          }
+        },
+        {
+          "range": {
+            "gte": 1013611.0,
+            "lte": 1055935.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "sign_y_coord",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.0018544274455261937,
+      "num_distinct_values": 14820,
+      "mean": 200925.25876683698,
+      "stddev": 30739.519568087075,
+      "coverage": [
+        {
+          "range": {
+            "gte": 139017.0,
+            "lte": 182585.0
+          }
+        },
+        {
+          "range": {
+            "gte": 186220.0,
+            "lte": 220158.0
+          }
+        },
+        {
+          "range": {
+            "gte": 226403.0,
+            "lte": 262430.0
+          }
+        }
+      ]
+    },
+    {
+      "name": "X",
+      "structural_type": "http://schema.org/Float",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.9987250811312007,
+      "mean": -8226693.0408593295,
+      "stddev": 6916.703258089649,
+      "coverage": [
+        {
+          "range": {
+            "gte": -8236745.27284958,
+            "lte": -8232042.13568306
+          }
+        },
+        {
+          "range": {
+            "gte": -8229438.32826561,
+            "lte": -8221965.66235569
+          }
+        },
+        {
+          "range": {
+            "gte": -8219562.24115362,
+            "lte": -8213783.16771273
+          }
+        }
+      ]
+    },
+    {
+      "name": "Y",
+      "structural_type": "http://schema.org/Float",
+      "semantic_types": [],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.9987250811312007,
+      "mean": 4968455.107036669,
+      "stddev": 7653.54044212944,
+      "coverage": [
+        {
+          "range": {
+            "gte": 4953042.22457378,
+            "lte": 4961955.55165921
+          }
+        },
+        {
+          "range": {
+            "gte": 4966934.41177261,
+            "lte": 4970809.66041161
+          }
+        },
+        {
+          "range": {
+            "gte": 4975762.34857951,
+            "lte": 4982330.7459673
+          }
+        }
+      ]
+    },
+    {
+      "name": "F_id",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.9987250811312007,
+      "num_distinct_values": 22
+    },
+    {
+      "name": "highway",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [
+        "http://schema.org/Enumeration"
+      ],
+      "missing_values_ratio": 0.9987250811312007,
+      "num_distinct_values": 1
+    },
+    {
+      "name": "direction",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "traffic_signals_direction",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.9999420491423273,
+      "num_distinct_values": 1
+    },
+    {
+      "name": "traffic_signals",
+      "structural_type": "http://schema.org/Text",
+      "semantic_types": [],
+      "missing_values_ratio": 0.9994784422809457,
+      "num_distinct_values": 1
+    },
+    {
+      "name": "crossing",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "kerb",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "button_operated",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "traffic_signals_sound",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "traffic_signals_vibration",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "tactile_paving",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "day_off",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "day_on",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "hour_off",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "hour_on",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "bicycle",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "name",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "name_es",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "note",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "photo",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "side",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "asset_ref",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "route_ref",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "stop",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "crossing_island",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "mapillary",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "survey_date",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "restriction_conditional",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "junction",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "turn_lanes_backward",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "description",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "noref",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "name_etymology_wikidata",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "name_etymology_wikipedia",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "crossing_markings",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "traffic_signals_countdown",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "ref",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "addr_housenumber",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "addr_postcode",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "addr_street",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "layer",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "tunnel",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "road_marking",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "historic",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "turn_lanes_forward",
+      "structural_type": "https://metadata.datadrivendiscovery.org/types/MissingData",
+      "semantic_types": []
+    },
+    {
+      "name": "ObjectId",
+      "structural_type": "http://schema.org/Integer",
+      "semantic_types": [
+        "http://schema.org/identifier"
+      ],
+      "unclean_values_ratio": 0.0,
+      "missing_values_ratio": 0.9987250811312007,
+      "num_distinct_values": 22,
+      "mean": 6474.590909090909,
+      "stddev": 2776.677030668966,
+      "coverage": [
+        {
+          "range": {
+            "gte": 522.0,
+            "lte": 4375.0
+          }
+        },
+        {
+          "range": {
+            "gte": 5418.0,
+            "lte": 8128.0
+          }
+        },
+        {
+          "range": {
+            "gte": 8554.0,
+            "lte": 9911.0
+          }
+        }
+      ]
+    }
+  ],
+  "nb_spatial_columns": 1,
+  "nb_temporal_columns": 3,
+  "nb_categorical_columns": 13,
+  "nb_numerical_columns": 15,
+  "types": [
+    "categorical",
+    "numerical",
+    "spatial",
+    "temporal"
+  ],
+  "spatial_coverage": [
+    {
+      "type": "point",
+      "column_names": [
+        "the_geom"
+      ],
+      "column_indexes": [
+        0
+      ],
+      "geohashes4": [
+        {
+          "hash": "1211302313323211",
+          "number": 1
+        },
+        {
+          "hash": "1211302313323210",
+          "number": 1
+        },
+        {
+          "hash": "1211302313301103",
+          "number": 1
+        },
+        {
+          "hash": "1211302313330112",
+          "number": 1
+        },
+        {
+          "hash": "1211302313313000",
+          "number": 1
+        },
+        {
+          "hash": "1211302312311102",
+          "number": 1
+        },
+        {
+          "hash": "1211302331013020",
+          "number": 1
+        },
+        {
+          "hash": "1211303220011223",
+          "number": 1
+        },
+        {
+          "hash": "1211303202212222",
+          "number": 1
+        },
+        {
+          "hash": "1211303202202110",
+          "number": 1
+        }
+      ],
+      "ranges": [
+        {
+          "range": {
+            "type": "envelope",
+            "coordinates": [
+              [
+                -73.99808355304516,
+                40.827242718096684
+              ],
+              [
+                -73.9103985790995,
+                40.73030173990866
+              ]
+            ]
+          }
+        },
+        {
+          "range": {
+            "type": "envelope",
+            "coordinates": [
+              [
+                -73.99558556219648,
+                40.5946937667643
+              ],
+              [
+                -73.99538556219647,
+                40.594493766764295
+              ]
+            ]
+          }
+        },
+        {
+          "range": {
+            "type": "envelope",
+            "coordinates": [
+              [
+                -73.8498776004042,
+                40.850900709240996
+              ],
+              [
+                -73.76855363006554,
+                40.67286274338786
+              ]
+            ]
+          }
+        }
+      ],
+      "number": 10
+    }
+  ],
+  "temporal_coverage": [
+    {
+      "type": "datetime",
+      "column_names": [
+        "Date_Insta"
+      ],
+      "column_indexes": [
+        10
+      ],
+      "column_types": [
+        "http://schema.org/DateTime"
+      ],
+      "ranges": [
+        {
+          "range": {
+            "gte": 1439078400.0,
+            "lte": 1491523200.0
+          }
+        },
+        {
+          "range": {
+            "gte": 1567296000.0,
+            "lte": 1615852800.0
+          }
+        },
+        {
+          "range": {
+            "gte": 1653004800.0,
+            "lte": 1716163200.0
+          }
+        }
+      ],
+      "temporal_resolution": "quarter"
+    },
+    {
+      "type": "datetime",
+      "column_names": [
+        "order_completed_on_date"
+      ],
+      "column_indexes": [
+        29
+      ],
+      "column_types": [
+        "http://schema.org/DateTime"
+      ],
+      "ranges": [
+        {
+          "range": {
+            "gte": -201139200.0,
+            "lte": 674956800.0
+          }
+        },
+        {
+          "range": {
+            "gte": 755308800.0,
+            "lte": 1303171200.0
+          }
+        },
+        {
+          "range": {
+            "gte": 1370476800.0,
+            "lte": 1736208000.0
+          }
+        }
+      ],
+      "temporal_resolution": "day"
+    },
+    {
+      "type": "datetime",
+      "column_names": [
+        "sign_design_voided_on_date"
+      ],
+      "column_indexes": [
+        33
+      ],
+      "column_types": [
+        "http://schema.org/DateTime"
+      ],
+      "ranges": [
+        {
+          "range": {
+            "gte": 1496361600.0,
+            "lte": 1496361600.0
+          }
+        },
+        {
+          "range": {
+            "gte": 1558483200.0,
+            "lte": 1558483200.0
+          }
+        }
+      ],
+      "temporal_resolution": "day"
+    }
+  ],
+  "attribute_keywords": [
+    "the_geom",
+    "the",
+    "geom",
+    "BoroCode",
+    "Boro",
+    "Code",
+    "BoroName",
+    "Boro",
+    "Name",
+    "BoroCD",
+    "Boro",
+    "CD",
+    "CounDist",
+    "Coun",
+    "Dist",
+    "AssemDist",
+    "Assem",
+    "Dist",
+    "StSenDist",
+    "St",
+    "Sen",
+    "Dist",
+    "CongDist",
+    "Cong",
+    "Dist",
+    "Location",
+    "Borough",
+    "Date_Insta",
+    "Date",
+    "Insta",
+    "POINT_X",
+    "POINT",
+    "X",
+    "POINT_Y",
+    "POINT",
+    "Y",
+    "FEMAFldz",
+    "FEMAFldT",
+    "FEMAFld",
+    "T",
+    "HrcEvac",
+    "Hrc",
+    "Evac",
+    "NTAname",
+    "source",
+    "order_number",
+    "order",
+    "number",
+    "record_type",
+    "record",
+    "type",
+    "order_type",
+    "order",
+    "type",
+    "borough",
+    "on_street",
+    "on",
+    "street",
+    "on_street_suffix",
+    "on",
+    "street",
+    "suffix",
+    "from_street",
+    "from",
+    "street",
+    "from_street_suffix",
+    "from",
+    "street",
+    "suffix",
+    "to_street",
+    "to",
+    "street",
+    "to_street_suffix",
+    "to",
+    "street",
+    "suffix",
+    "side_of_street",
+    "side",
+    "of",
+    "street",
+    "order_completed_on_date",
+    "order",
+    "completed",
+    "on",
+    "date",
+    "sign_code",
+    "sign",
+    "code",
+    "sign_description",
+    "sign",
+    "description",
+    "sign_size",
+    "sign",
+    "size",
+    "sign_design_voided_on_date",
+    "sign",
+    "design",
+    "voided",
+    "on",
+    "date",
+    "sign_location",
+    "sign",
+    "location",
+    "distance_from_intersection",
+    "distance",
+    "from",
+    "intersection",
+    "arrow_direction",
+    "arrow",
+    "direction",
+    "facing_direction",
+    "facing",
+    "direction",
+    "sheeting_type",
+    "sheeting",
+    "type",
+    "support",
+    "sign_notes",
+    "sign",
+    "notes",
+    "sign_x_coord",
+    "sign",
+    "x",
+    "coord",
+    "sign_y_coord",
+    "sign",
+    "y",
+    "coord",
+    "X",
+    "Y",
+    "F_id",
+    "F",
+    "id",
+    "highway",
+    "direction",
+    "traffic_signals_direction",
+    "traffic",
+    "signals",
+    "direction",
+    "traffic_signals",
+    "traffic",
+    "signals",
+    "crossing",
+    "kerb",
+    "button_operated",
+    "button",
+    "operated",
+    "traffic_signals_sound",
+    "traffic",
+    "signals",
+    "sound",
+    "traffic_signals_vibration",
+    "traffic",
+    "signals",
+    "vibration",
+    "tactile_paving",
+    "tactile",
+    "paving",
+    "day_off",
+    "day",
+    "off",
+    "day_on",
+    "day",
+    "on",
+    "hour_off",
+    "hour",
+    "off",
+    "hour_on",
+    "hour",
+    "on",
+    "bicycle",
+    "name",
+    "name_es",
+    "name",
+    "es",
+    "note",
+    "photo",
+    "side",
+    "asset_ref",
+    "asset",
+    "ref",
+    "route_ref",
+    "route",
+    "ref",
+    "stop",
+    "crossing_island",
+    "crossing",
+    "island",
+    "mapillary",
+    "survey_date",
+    "survey",
+    "date",
+    "restriction_conditional",
+    "restriction",
+    "conditional",
+    "junction",
+    "turn_lanes_backward",
+    "turn",
+    "lanes",
+    "backward",
+    "description",
+    "noref",
+    "name_etymology_wikidata",
+    "name",
+    "etymology",
+    "wikidata",
+    "name_etymology_wikipedia",
+    "name",
+    "etymology",
+    "wikipedia",
+    "crossing_markings",
+    "crossing",
+    "markings",
+    "traffic_signals_countdown",
+    "traffic",
+    "signals",
+    "countdown",
+    "ref",
+    "addr_housenumber",
+    "addr",
+    "housenumber",
+    "addr_postcode",
+    "addr",
+    "postcode",
+    "addr_street",
+    "addr",
+    "street",
+    "layer",
+    "tunnel",
+    "road_marking",
+    "road",
+    "marking",
+    "historic",
+    "turn_lanes_forward",
+    "turn",
+    "lanes",
+    "forward",
+    "ObjectId",
+    "Object",
+    "Id"
+  ]
+}

--- a/metadata/signals_markings_signs.yaml
+++ b/metadata/signals_markings_signs.yaml
@@ -1,0 +1,77 @@
+dataset_id: "signals_markings_signs"
+name: "Signals, Signs, and Markings (NYC Combined)"
+description: >
+  A unified, deduplicated dataset combining key NYC DOT spatial sources:
+  accessible pedestrian signal locations, street sign work orders, and traffic signal infrastructure.
+  Each dataset is harmonized into point geometry, and duplicate feature IDs within each source are removed.
+
+source_organization:
+  accessible_pedestrian_signals: "New York City Department of Transportation (NYC DOT)"
+  street_sign_work_orders: "New York City Department of Transportation (NYC DOT)"
+  traffic_signals_arcgis: "Esri Open Data (ArcGIS Hub - New York Street Light Layer)"
+
+domain: "transportation"
+last_updated: "2025-06-11"
+update_frequency:
+  accessible_pedestrian_signals: "Monthly"
+  street_sign_work_orders: "Periodic"
+  traffic_signals_arcgis: "As available"
+
+access:
+  primary_url: "https://data.cityofnewyork.us"
+  api_endpoint:
+    accessible_pedestrian_signals: "https://data.cityofnewyork.us/resource/de3m-c5p4.json"
+    street_sign_work_orders: "https://data.cityofnewyork.us/resource/qt6m-xctn.json"
+    traffic_signals_arcgis: "https://hub.arcgis.com/datasets/uji::newyork-street-light/about"
+  license: "Open Data License"
+  file_format:
+    accessible_pedestrian_signals: ["CSV", "JSON"]
+    street_sign_work_orders: ["CSV", "JSON"]
+    traffic_signals_arcgis: ["Shapefile", "GeoJSON", "CSV"]
+  rate_limits:
+    accessible_pedestrian_signals: "Unknown"
+    street_sign_work_orders: "Unknown"
+    traffic_signals_arcgis: "Unknown"
+
+spatial:
+  geometry_type: "point"
+  coordinate_system: "EPSG:4326"
+  coverage_area: "NYC"
+
+temporal:
+  temporal_type:
+    accessible_pedestrian_signals: "installation"
+    street_sign_work_orders: "maintenance activity"
+    traffic_signals_arcgis: "infrastructure snapshot"
+  temporal_resolution:
+    accessible_pedestrian_signals: "monthly"
+    street_sign_work_orders: "irregular"
+    traffic_signals_arcgis: "unknown"
+  time_column:
+    accessible_pedestrian_signals: "Date_Insta"
+    street_sign_work_orders: "CompletedDate"
+    traffic_signals_arcgis: "N/A"
+
+implementation:
+  downloader_module:
+    accessible_pedestrian_signals: "downloaders.signals_marking_signs.accessible_pedestrian_signals_downloader"
+    street_sign_work_orders: "downloaders.signals_marking_signs.street_sign_work_orders_downloader"
+    traffic_signals_arcgis: "downloaders.signals_marking_signs.traffic_signals_downloader"
+  processor_module: "processors.signals_markings_signs"
+  example_notebook: "examples/signals_markings_signs.ipynb"
+
+integration_opportunities:
+  spatial_joins:
+    - "crash reports or pedestrian injury locations"
+    - "intersection geometries"
+    - "street centerlines"
+    - "school zones or pedestrian priority zones"
+  temporal_alignment: []
+
+map_algebra:
+  raster_conversion:
+    suitable_for_rasterization: true
+    recommended_cell_size: ""
+    interpolation_method: ""
+
+data_name: "signals_markings_signs"


### PR DESCRIPTION

# Signals, Signs, and Markings (NYC Combined) Dataset

## Overview

This dataset contains a comprehensive collection of NYC street infrastructure elements, combining data for accessible pedestrian signals (APS), street signs, and traffic signals into a single, deduplicated geospatial dataset.

## Dataset Generation

The dataset is generated using `processors/signals_markings_signs.py`, a data processing script designed to merge several NYC geospatial datasets related to street infrastructure.

### Purpose
The script combines data for three types of street features—accessible pedestrian signals (APS), street signs, and traffic signals—into a single, deduplicated geospatial dataset.

### How it works

#### 1. Load Data
* Reads three CSV files containing information about APS, street signs, and traffic signals.
* The source datasets are downloaded using `downloaders/signals_markings_signs/main_downloader.py`

#### 2. Deduplication & Geospatial Conversion
* For each dataset, it:
  * Removes entries with missing coordinates.
  * Converts X/Y coordinates into geospatial points using GeoPandas.
  * Deduplicates entries within each source using a unique ID column.

#### 3. Merging
* Combines the cleaned datasets into one unified table.

#### 4. Output
* Saves the merged dataset (without geometry columns) as a CSV file.
* Data profile information and metadata is also included for the final dataset.

## What's Included
* Accessible Pedestrian Signals (APS)
* Street Signs
* Traffic Signals

## What's Not Included
* Speed limits or other features beyond APS, street signs, and traffic signals.

## Usage
This dataset is useful for generating comprehensive street-level infrastructure data for further geospatial analysis or visualization, as part of the wider Complete Streets Artificial Intelligence (CSAI) Initiative.

